### PR TITLE
task #8: enabled inlay type hints and autoformat on save in Helix editor

### DIFF
--- a/dotfiles/helix/config.toml
+++ b/dotfiles/helix/config.toml
@@ -7,6 +7,10 @@ completion-replace = true
 trim-trailing-whitespace = true
 insert-final-newline = true
 end-of-line-diagnostics = "hint"
+auto-format = true
+
+[editor.lsp]
+display-inlay-hints = true
 
 [editor.statusline]
 right = ["version-control", "position"]


### PR DESCRIPTION
## Summary
Enables inlay type hints and autoformat on save for Helix editor.

## Changes
list the key changes in this PR:
- [x] Extends Helix editor config.

## Checklist
- [x] I have tested my changes locally
- [x] I added/updated documentation if needed
- [x] I added/updated tests
- [x] CI pipeline is passing

## Related Issues
Closes #8
